### PR TITLE
[Objects Version] Tweak bulk loading logic

### DIFF
--- a/migration_scripts/bulk_load/src/db.clj
+++ b/migration_scripts/bulk_load/src/db.clj
@@ -13,3 +13,9 @@
     :port     (or port     (env "DBPORT") "5432")
     :user     (or user     (env "DBUSER") "postgres")
     :password (or password (env "DBPASS") "postgrespw")}))
+
+(defn max-checkpoint
+  "Get the maximum checkpoint sequence number."
+  [db] (->> ["SELECT MAX(checkpoint_sequence_number) FROM objects_history"]
+            (jdbc/execute-one! db)
+            (:max)))


### PR DESCRIPTION
## Description

Changes the parametrisation of the `objects_version` bulk loader. Previously, it used 20 workers, and processed batches of 1M checkpoints at a time, per partition, now it processes 100K checkpoints at a time, per partition, using 50 workers.

This change was made after recognising that for hot periods on the network, the bulk loader was wasting work by timing out multiple times on sections until it eventually settled on a batch size of around 100K.

## Test plan

Run a bulk load and see that it takes less time than before.