### PR TITLE
[Bulk Load] Normalized Transaction Benchmark

### DIFF
--- a/migration_scripts/bulk_load/src/bench.clj
+++ b/migration_scripts/bulk_load/src/bench.clj
@@ -1,0 +1,74 @@
+(ns bench
+  (:require [combinations :refer [*?]]
+            [db]
+            [pool :refer [->Pool signal-swap!]]
+            [next.jdbc :as jdbc])
+  (:refer-clojure :exclude [run!]))
+
+(defn signals
+  "Signals produced by running benchmarks.
+
+  Benchmarks split inputs into two categories: success and failure.
+  Failed benchmarks are ones that produced some kind of unexpected
+  error. All other benchmarks are considered successful, including
+  benchmarks that timed out."
+  [] (pool/signals :success [] :failure []))
+
+(defn run!
+  "Gather plan times and execution times for various `inputs` to
+  `benchmark`.
+
+  `signals` is expected to be an `atom` containing a map with keys
+  `:success` and `:failure`."
+  [benchmark db inputs logger timeout signals]
+  (->Pool :name   "run-benchmark"
+          :logger  logger
+          :workers 50
+
+          :pending inputs
+
+          :impl
+          (db/worker input
+            (->> (apply concat input)
+                 (apply benchmark)
+                 (db/explain-analyze-json! db timeout)))
+
+          :finalize
+          (fn [{:as task :keys [status]}]
+            (case status
+              (:success :timeout)
+              (do (signal-swap! signals :success conj task) nil)
+              :error
+              (do (signal-swap! signals :failure conj task) nil)))))
+
+(defn success-rates
+  "Given a sequence of benchmark results, returns the rate at which
+  queries timeout.
+
+  Returns a map from sets of keys in benchmark results to their
+  success rate (proportion of queries including these keys that did
+  not timeout)."
+  [results]
+  (let [success (atom {})
+        timeout (atom {})
+        or-zero  #(fn [x] (% (or x 0)))
+        success! #(swap! success update % (or-zero inc))
+        timeout! #(swap! timeout update % (or-zero dec))]
+    (doseq [result results
+            :when (or (= :timeout (:status result))
+                      (pos? (:actual-rows result)))
+            keys (as-> result % (keys %) (into #{} %)
+                   (disj % :status :planning-time :execution-time :actual-rows)
+                   (*? (lazy-seq %)))]
+      (case (:status result)
+        :success (success! keys)
+        :timeout (timeout! keys)))
+    (-> (merge-with
+          (fn [s t] (/ (double s) (- s t)))
+          @success @timeout)
+        (update-vals
+         (fn [rate]
+           (cond
+             (double? rate) rate
+             (neg? rate) 0.0
+             (pos? rate) 1.0))))))

--- a/migration_scripts/bulk_load/src/hex.clj
+++ b/migration_scripts/bulk_load/src/hex.clj
@@ -1,0 +1,20 @@
+(ns hex
+  (:require [clojure.string :as s]))
+
+(defn hex->bytes
+  "Convert a hex literal string into a length 32 byte array.
+
+  The hex literal may have trailing zeroes removed, and can be in a
+  normal literal form (starting with 0x) or in a postgres form
+  starting with \\x."
+  [hex]
+  (assert (or (s/starts-with? hex "0x")
+              (s/starts-with? hex "\\x"))
+          "Hex literals must start with '0x'")
+  (as-> hex %
+      (subs % 2)
+      (format "%64s" %)
+      (s/replace % \space \0)
+      (partition 2 %)
+      (map #(-> % s/join (Integer/parseInt 16)) %)
+      (byte-array %)))

--- a/migration_scripts/bulk_load/src/norm_tx_benchmark.clj
+++ b/migration_scripts/bulk_load/src/norm_tx_benchmark.clj
@@ -1,0 +1,215 @@
+(ns norm-tx-benchmark
+  (:require [combinations :refer [&& || |?]]
+            [db]
+            [hex :refer [hex->bytes]]
+            [norm-tx
+             :refer [+transactions+
+                     +tx-calls-pkg+ +tx-calls-mod+ +tx-calls-fun+
+                     +tx-senders+ +tx-recipients+
+                     +tx-input-objects+ +tx-changed-objects+
+                     +tx-digests+ +cp-tx+
+                     +tx-system+]]
+            [alphabase.base58 :as b58]
+            [honey.sql :as sql]))
+
+;; # Normalized Transactions Benchmark
+;;
+;; Testing out similar queries as in `tx-benchmark`, but on the
+;; normalized table.
+;;
+;; The main differences are:
+;;
+;; - Cursors refer to just the transaction sequence number, and not
+;;   also the checkpoint sequence number.
+;;
+;; - Each filter applies to a separate table, the results are joined
+;;   together, and finally the resulting ordered set of transaction
+;;   sequence numbers is used to probe into the `transactions` table.
+;;
+;; - The final join (against `transactions`) is a `LEFT JOIN` to force
+;;   all previous inner joins to be done first. This is to take
+;;   advantage of the fact that the previous joins should limit the
+;;   final result.
+;;
+;; This approach *did not* work as hoped -- in general it yielded
+;; worse performance than the existing schema (see below):
+;;
+;;     [#{:pkg} 0.18803418803418803]
+;;     [#{:mod} 0.1891891891891892]
+;;     [#{:fun} 0.21739130434782608]
+;;     [#{:kind} 0.29770992366412213]
+;;     [#{:cp-<} 0.37988826815642457]
+;;     [#{:changed} 0.38596491228070173]
+;;     [#{:input} 0.42857142857142855]
+;;     [#{:before} 0.45320197044334976]
+;;     [#{:cp->} 0.46875]
+;;     [#{:after} 0.5526315789473685]
+;;     [#{:ids} 0.7857142857142857]
+;;     [#{:cp-=} 1.0]
+;;
+;;       Fig 1. Success rates for queries that include at least one
+;;       filter key.
+;;
+;;
+;;     [#{:changed :pkg} 0.0]
+;;     [#{:mod :changed} 0.0]
+;;     [#{:fun :changed} 0.0]
+;;     [#{:kind :pkg} 0.04878048780487805]
+;;     [#{:mod :kind} 0.05555555555555555]
+;;     [#{:fun :kind} 0.05714285714285714]
+;;     [#{:fun :input} 0.07692307692307693]
+;;     [#{:mod :input} 0.09523809523809523]
+;;
+;;       Fig 2. Worst success rates for queries with combinations of
+;;       at least two filter keys.
+;;
+;; The issue seems to be in Postgres' implementation of Merge Join,
+;; which does not have a way to skip over pages of one relation based
+;; on the next row to merge in another relation (like leapfrog trie
+;; join): Sets of queries with low intersectionality, will result
+;; in (effectively) whole table scans.
+
+(defn norm-tx-filter
+  [& {:keys [pkg mod fun    ;; function
+             kind           ;; transaction kind
+             cp-< cp-= cp-> ;; checkpoint
+             sign recv addr ;; addresses
+             input changed  ;; objects
+             ids            ;; transaction ids
+             after before   ;; pagination
+
+             ;; Configuration
+             inline]}]
+  (let [f-> #(keyword (str %1 "." (name %2)))
+
+        tables
+        (cond-> []
+          (or pkg mod fun)
+          (conj (cond
+                  (and pkg mod fun) +tx-calls-fun+
+                  (and pkg mod)     +tx-calls-mod+
+                  :else             +tx-calls-pkg+))
+
+          sign (conj +tx-senders+)
+          recv (conj +tx-recipients+)
+
+          input   (conj +tx-input-objects+)
+          changed (conj +tx-changed-objects+)
+
+          ids   (conj +tx-digests+)
+          :true (conj +transactions+))
+
+        sources
+        {:from    (keyword (first tables))
+         :join-by (reduce (fn [joins table]
+                            (conj joins
+                                  (if (= +transactions+ table)
+                                    :left-join :join)
+                                  [(keyword table)
+                                   [:using :tx-sequence-number]]))
+                          [] (rest tables))}
+
+        filters
+        (cond-> [:and]
+          (and pkg mod fun)
+          (conj [:= (f-> +tx-calls-fun+ :package) (hex->bytes pkg)]
+                [:= (f-> +tx-calls-fun+ :module) mod]
+                [:= (f-> +tx-calls-fun+ :func) fun])
+
+          (and pkg mod (not fun))
+          (conj [:= (f-> +tx-calls-mod+ :package) (hex->bytes pkg)]
+                [:= (f-> +tx-calls-mod+ :module) mod])
+
+          (and pkg (not mod) (not fun))
+          (conj [:= (f-> +tx-calls-pkg+ :package) (hex->bytes pkg)])
+
+          sign (conj [:= (f-> +tx-senders+ :sender) (hex->bytes sign)])
+          recv (conj [:= (f-> +tx-recipients+ :recipient) (hex->bytes recv)])
+
+          addr
+          (conj [:in :tx-sequence-number
+                 [:union-all
+                  {:select [:tx-sequence-number]
+                   :from   [(keyword +tx-senders+)]
+                   :where  [:= :sender (hex->bytes addr)]}
+                  {:select [:tx-sequence-number]
+                   :from   [(keyword +tx-recipients+)]
+                   :where  [:= :recipient (hex->bytes addr)]}]])
+
+          input
+          (conj [:= (f-> +tx-input-objects+ :object-id) (hex->bytes input)])
+
+          changed
+          (conj [:= (f-> +tx-changed-objects+ :object-id) (hex->bytes changed)])
+
+          ids
+          (conj [:in (f-> +tx-digests+ :tx-digest) (map b58/decode ids)])
+
+          kind
+          (conj [({:system :in :programmable :not-in} kind)
+                 :tx-sequence-number
+                 {:select [:tx-sequence-number]
+                  :from   [(keyword +tx-system+)]}])
+
+          cp-<
+          (conj [:< :tx-sequence-number
+                 {:select [:min-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp-<]}])
+
+          cp-=
+          (conj [:between :tx-sequence-number
+                 {:select [:min-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp-=]}
+                 {:select [:max-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp-=]}])
+
+          cp->
+          (conj [:> :tx-sequence-number
+                 {:select [:max-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp->]}])
+
+          after  (conj [:>= :tx-sequence-number after])
+          before (conj [:<= :tx-sequence-number before]))]
+    (-> {:select [(f-> +transactions+ :*)]
+         :where filters
+         :limit  52
+         :order-by [[:tx-sequence-number :asc]]}
+        (merge sources)
+        (sql/format :inline inline))))
+
+(def inputs
+  "Lazy sequence containing various inputs to `norm-tx-filter`."
+  (&& {:kind (|? :system :programmable)}
+
+      (|? (&& {:pkg "0x2"} (|? (&& {:mod "transfer"}
+                                   {:fun (|? "public_transfer"
+                                             "public_share_object")})
+                               {:mod "package"
+                                :fun "make_immutable"}))
+          (&& {:pkg "0x225a5eb5c580cb6b6c44ffd60c4d79021e79c5a6cea7eb3e60962ee5f9bc6cb2"}
+              (|? {:mod "game_8192"
+                   :fun (|? "make_move") })))
+
+      (|| {:cp-< 10428013}
+          {:cp-= 10428013}
+          {:cp-> 10427513
+           :cp-< 10428013})
+
+      (|? {:input   "0x6"}
+          {:changed "0x6"})
+
+      (|?
+       ;; Arbitrary transactions at a variety of checkpoints
+       {:ids ["B5FEom9XbGShf9LkqgC7UzhpEvVFVk6AakhXaFyfRWRf"
+              "8GcwVK8cNqyM4CeY77Au2UfTsM6fZftSGjmfNxM8AN9"]}
+
+       ;; Transactions that modify the clock
+       {:ids ["FLqdHsKounJHXGsoT983JoZ4fuTF2UvSrVJJLDXRHqGe"
+              "85uiG9US4T4ARCiWbFSeGCawryKejZ328rxwZfysutBk"]})
+
+      (|? {:after  746619070})
+      (|? {:before 746625335})))


### PR DESCRIPTION
## Description


Simulate transaction block pagination as if it were implemented on top of normalized transaction schema. **This doesn't yield a good result unfortunately, because Postgres' implementation of merge join is not as efficient as we would like.**

Also splits out logic for running benchmarks into its own module.

## Test Plan

Ran benchmarks (see results in doc comment of benchmark file).

## Stack

- #7 
- #9 
- #10 