### PR TITLE
[Bulk Load] 1-GIN Transactions

### DIFF
--- a/migration_scripts/bulk_load/src/db.clj
+++ b/migration_scripts/bulk_load/src/db.clj
@@ -46,23 +46,31 @@
 
 (defn disable-autovacuum!
   "Disable auto-vacuum for a table."
-  [db name timeout]
-  (with-table! db name
-    "ALTER TABLE %s SET (autovacuum_enabled = false)"
-    {:timeout timeout}))
+  ([db name]
+   (with-table! db name
+     "ALTER TABLE %s SET (autovacuum_enabled = false)"))
+  ([db name timeout]
+   (with-table! db name
+     "ALTER TABLE %s SET (autovacuum_enabled = false)"
+     {:timeout timeout})))
 
 (defn reset-autovacuum!
   "Reset the decision on whether to auto-vacuum or not to the
   database-wide setting."
-  [db name timeout]
-  (with-table! db name
-    "ALTER TABLE %s RESET (autovacuum_enabled)"
-    {:timeout timeout}))
+  ([db name]
+   (with-table! db name
+     "ALTER TABLE %s RESET (autovacuum_enabled)"))
+  ([db name timeout]
+   (with-table! db name
+     "ALTER TABLE %s RESET (autovacuum_enabled)"
+     {:timeout timeout})))
 
 (defn vacuum-and-analyze!
   "Vacuum and analyze a table."
-  [db name timeout]
-  (with-table! db name "VACUUM ANALYZE %s" {:timeout timeout}))
+  ([db name]
+   (with-table! db name "VACUUM ANALYZE %s"))
+  ([db name timeout]
+   (with-table! db name "VACUUM ANALYZE %s" {:timeout timeout})))
 
 (defn cancel!
   "Cancel query matching `filter`.
@@ -141,6 +149,26 @@
             (if (= "57014" (.getSQLState e#))
               (reply# (assoc param# :status :timeout))
               (reply# (assoc param# :status :error :error e#))))
+          (catch Throwable t#
+            (reply# (assoc param# :status :error :error t#))))))
+
+(defmacro worker-v2
+  "Create a worker function for a pool.
+
+  The worker is passed a description of the unit of work (expected to
+  be a map) which is bound to `param`, and then its `body` is
+  evaluated. The return value of `body` is merged with the description
+  of the work and sent back to the supervisor, along with a `:status`
+  of `:success`.
+
+  The returned worker detects errors (including timeouts), returning
+  the description of work with a `:status` of `:error`. Errors are
+  additionally annotated with the `:error` itself."
+  [param & body]
+  `(fn [param# reply#]
+     (try (->> (let [~param param#] ~@body)
+               (merge param# {:status :success})
+               (reply#))
           (catch Throwable t#
             (reply# (assoc param# :status :error :error t#))))))
 

--- a/migration_scripts/bulk_load/src/gin_1_tx.clj
+++ b/migration_scripts/bulk_load/src/gin_1_tx.clj
@@ -1,0 +1,504 @@
+(ns gin-1-tx
+  (:require [db]
+            [logger :refer [->Logger] :as l]
+            [next.jdbc :as jdbc]
+            [pool-v2 :refer [->Pool worker]]
+            [transactions :refer [bounds->batches]]))
+
+;; # 1-GIN Transactions Schema
+;;
+;; Proposed new schema for the transactions table which eschews most side
+;; tables. Instead, the data is stored in a single (partitioned) table, acting
+;; as a document store (transactions are stored in a denormalized form).
+;;
+;; The one exception to this rule is the `tx_digests` table which is still used
+;; for point (and multi-point/data-loader) lookups.
+;;
+;; Like the previously proposed "normalized" schema, partitioning and cursor
+;; logic will rely solely on transaction sequence number (not involve checkpoint
+;; sequence number).
+;;
+;; Queries are powered by a single, multi-column GIN (Generalized Inverted
+;; iNdex) containing all the queryable fields on the denormalized transaction.
+;;
+;; All queries will effectively be translated into a bitmap index scan, with the
+;; bitmap produced by the GIN. Combination filters are naturally supported in
+;; this mode (a multi-column GIN can support arbirary combinations of its
+;; columns).
+;;
+;; The `btree_gin` extension needs to be enabled to support GIN indices
+;; with "normal" (scalar) types.
+;;
+;; This schema should be good at supporting arbitrary combinations of filters,
+;; without much storage overhead, but:
+;;
+;; - Write throughput may suffer as GINs are somewhat slow to update (although
+;;   maybe not because the GIN is replacing many indices).
+;;
+;; - It may naturally time-out on queries that don't bound the number of
+;;   partitions it needs to look-up.
+
+;; Table Names ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def ^:private prefix "amnn_0_gin_1_")
+
+(def +transactions+ (str prefix "transactions"))
+(def +tx-digests+   (str prefix "tx_digests"))
+(def +cp-tx+        (str prefix "cp_tx"))
+
+(defn transactions:partition-name [n]
+  (str +transactions+ "_partition_" n))
+
+;; Table: gin_1_transactions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn transactions:create! [db]
+  (jdbc/with-transaction [tx db]
+    (jdbc/execute! tx ["CREATE EXTENSION IF NOT EXISTS btree_gin"])
+    (db/with-table! tx +transactions+
+      "CREATE TABLE %s (
+           tx_sequence_number         BIGINT          PRIMARY KEY,
+           transaction_digest         BYTEA           NOT NULL,
+           raw_transaction            BYTEA           NOT NULL,
+           raw_effects                BYTEA           NOT NULL,
+           checkpoint_sequence_number BIGINT          NOT NULL,
+           timestamp_ms               BIGINT          NOT NULL,
+           object_changes             BYTEA[]         NOT NULL,
+           balance_changes            BYTEA[]         NOT NULL,
+           events                     BYTEA[]         NOT NULL,
+           transaction_kind           SMALLINT        NOT NULL,
+           success_command_count      SMALLINT        NOT NULL,
+           packages                   BYTEA[]         NOT NULL,
+           modules                    TEXT[]          NOT NULL,
+           functions                  TEXT[]          NOT NULL,
+           senders                    BYTEA[]         NOT NULL,
+           recipients                 BYTEA[]         NOT NULL,
+           inputs                     BYTEA[]         NOT NULL,
+           changed                    BYTEA[]         NOT NULL
+       ) PARTITION BY RANGE (tx_sequence_number)")
+    (db/with-table! tx +transactions+
+      "CREATE INDEX %1$s_filter ON %1$s USING gin(
+           transaction_digest,
+           transaction_kind,
+           packages, modules, functions,
+           senders, recipients,
+           inputs, changed
+       )")))
+
+(defn transactions:create-partition! [db n]
+  (jdbc/with-transaction [tx db]
+    (db/with-table! tx (transactions:partition-name n)
+      "CREATE TABLE %s (
+           tx_sequence_number         BIGINT,
+           transaction_digest         BYTEA,
+           raw_transaction            BYTEA,
+           raw_effects                BYTEA,
+           checkpoint_sequence_number BIGINT,
+           timestamp_ms               BIGINT,
+           object_changes             BYTEA[],
+           balance_changes            BYTEA[],
+           events                     BYTEA[],
+           transaction_kind           SMALLINT,
+           success_command_count      SMALLINT,
+           packages                   BYTEA[],
+           modules                    TEXT[],
+           functions                  TEXT[],
+           senders                    BYTEA[],
+           recipients                 BYTEA[],
+           inputs                     BYTEA[],
+           changed                    BYTEA[]
+       )")
+    (db/disable-autovacuum! tx (transactions:partition-name n))))
+
+(defn transactions:constrain!
+  "Add constraints to partition `n` of the `transactions` table.
+
+  `lo` and `hi` are the inclusive and exclusive bounds on transaction
+  sequence numbers in the partition."
+  [db n lo hi]
+  (->> [(format
+         "ALTER TABLE %1$s
+          ADD PRIMARY KEY (tx_sequence_number),
+          ALTER COLUMN transaction_digest         SET NOT NULL,
+          ALTER COLUMN raw_transaction            SET NOT NULL,
+          ALTER COLUMN raw_effects                SET NOT NULL,
+          ALTER COLUMN checkpoint_sequence_number SET NOT NULL,
+          ALTER COLUMN timestamp_ms               SET NOT NULL,
+          ALTER COLUMN object_changes             SET NOT NULL,
+          ALTER COLUMN balance_changes            SET NOT NULL,
+          ALTER COLUMN events                     SET NOT NULL,
+          ALTER COLUMN transaction_kind           SET NOT NULL,
+          ALTER COLUMN success_command_count      SET NOT NULL,
+          ALTER COLUMN packages                   SET NOT NULL,
+          ALTER COLUMN modules                    SET NOT NULL,
+          ALTER COLUMN functions                  SET NOT NULL,
+          ALTER COLUMN senders                    SET NOT NULL,
+          ALTER COLUMN recipients                 SET NOT NULL,
+          ALTER COLUMN inputs                     SET NOT NULL,
+          ALTER COLUMN changed                    SET NOT NULL,
+          ADD CONSTRAINT %1$s_partition_check CHECK (
+              %2$d <= tx_sequence_number
+          AND tx_sequence_number < %3$d
+          )"
+         (transactions:partition-name n) lo hi)]
+       (jdbc/execute! db)))
+
+(defn transactions:index-filters! [db n]
+  (db/with-table! db (transactions:partition-name n)
+    "CREATE INDEX %1$s_filter ON %1$s USING gin(
+         transaction_digest,
+         transaction_kind,
+         packages, modules, functions,
+         senders, recipients,
+         inputs, changed
+     )"))
+
+(defn transactions:attach! [db n lo hi]
+  (jdbc/with-transaction [tx db]
+    (let [part   (transactions:partition-name n)
+          attach (fn [template]
+                   (jdbc/execute!
+                    tx [(format template +transactions+ part lo hi)]))]
+      (attach "ALTER TABLE %1$s
+               ATTACH PARTITION %2$s FOR VALUES FROM (%3$d) TO (%4$d)")
+      (attach "ALTER INDEX %1$s_filter ATTACH PARTITION %2$s_filter"))))
+
+(defn transactions:drop-range-check! [db n]
+  (db/with-table! db (transactions:partition-name n)
+    "ALTER TABLE %1$s DROP CONSTRAINT %1$s_partition_check"))
+
+;; Table: gin_1_tx_digests ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn tx-digests:create! [db]
+  (jdbc/with-transaction [tx db]
+    (db/with-table! db +tx-digests+
+      "CREATE TABLE %s (
+            tx_digest                   BYTEA,
+            tx_sequence_number          BIGINT
+       )")
+    (db/disable-autovacuum! tx +tx-digests+)))
+
+(defn tx-digests:constrain! [db]
+  (db/with-table! db +tx-digests+
+    "ALTER TABLE %1$s
+     ADD PRIMARY KEY (tx_digest, tx_sequence_number),
+     ADD CONSTRAINT %1$s_unique UNIQUE (tx_digest)"))
+
+;; Table: gin_1_cp_tx ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn cp-tx:create! [db]
+  (jdbc/with-transaction [tx db]
+    (db/with-table! db +cp-tx+
+      "CREATE TABLE %s (
+            checkpoint_sequence_number  BIGINT,
+            min_tx_sequence_number      BIGINT,
+            max_tx_sequence_number      BIGINT
+       )")
+    (db/disable-autovacuum! tx +cp-tx+)))
+
+(defn cp-tx:constrain! [db]
+  (db/with-table! db +cp-tx+
+    "ALTER TABLE %1$s
+     ADD PRIMARY KEY (checkpoint_sequence_number),
+     ALTER COLUMN min_tx_sequence_number SET NOT NULL,
+     ALTER COLUMN max_tx_sequence_number SET NOT NULL"))
+
+;; Bulk Loading ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn transactions:create-all!
+  "Create all relevant transactions tables.
+
+  Creates the main table, partitions between `lo` (inclusive) and
+  `hi` (exclusive), and all the indexing tables, on `db`."
+  [db lo hi logger & {:keys [retry]}]
+  (->Pool :name    "create-tables"
+          :logger   logger
+          :workers (Math/clamp (- hi lo) 4 20)
+
+          :pending
+          (or retry
+              (conj (for [n (range lo hi)]
+                      {:fn #(transactions:create-partition! % n)
+                       :label (str "partition-" n)})
+                    {:fn transactions:create! :label "transactions"}
+                    {:fn tx-digests:create! :label "tx-digests"}
+                    {:fn cp-tx:create! :label "cp-tx"}))
+
+          :impl
+          (worker {builder :fn}
+            (builder db) nil)))
+
+(defn transactions:drop-all!
+  "Drop all relevant transactions tables."
+  [db lo hi logger & {:keys [retry]}]
+  (->Pool :name    "drop-tables"
+          :logger   logger
+          :workers (Math/clamp (- hi lo) 4 20)
+
+          :pending
+          (or retry
+              (conj (for [n (range lo hi)]
+                      {:table (transactions:partition-name n)})
+                    {:table +transactions+}
+                    {:table +tx-digests+}
+                    {:table +cp-tx+}))
+
+          :impl
+          (worker {:keys [table]}
+            (db/with-table! db table "DROP TABLE IF EXISTS %s")
+            nil)))
+
+(defn transactions:bulk-load!
+  "Bulk load all transactions into the 1-GIN subset tables.
+
+  Transfers data from the partitions of the `transactions` table, as
+  well as from the index tables. `bounds` is a sequence containing the
+  bounds of partitions to load into, in transaction sequence numbers,
+  and `batch` is their batch size."
+  [db bounds batch logger & {:keys [retry]}]
+  (->Pool :name   "tx:bulk-load"
+          :logger  logger
+          :workers 100
+
+          :pending
+          (or retry
+              (for [batch (-> bounds (bounds->batches batch))
+                    table [:transactions :tx-digests]]
+                (assoc batch :fill table)))
+
+          :impl
+          (worker {:keys [lo hi part fill]}
+            (->> [(case fill
+                    :transactions
+                    (format
+                     "INSERT INTO %s
+                      SELECT
+                              t.tx_sequence_number,
+                              t.transaction_digest,
+                              t.raw_transaction,
+                              t.raw_effects,
+                              t.checkpoint_sequence_number,
+                              t.timestamp_ms,
+                              t.object_changes,
+                              t.balance_changes,
+                              t.events,
+                              t.transaction_kind,
+                              t.success_command_count,
+                              ARRAY(
+                                      SELECT DISTINCT
+                                              package
+                                      FROM
+                                              tx_calls i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) packages,
+                              ARRAY(
+                                      SELECT DISTINCT
+                                              '0x' || ENCODE(package, 'hex') ||
+                                              '::' || module
+                                      FROM
+                                              tx_calls i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) modules,
+                              ARRAY(
+                                      SELECT DISTINCT
+                                              '0x' || ENCODE(package, 'hex') ||
+                                              '::' || module ||
+                                              '::' || func
+                                      FROM
+                                              tx_calls i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) functions,
+                              ARRAY(
+                                      SELECT
+                                              sender
+                                      FROM
+                                              tx_senders i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) senders,
+                              ARRAY(
+                                      SELECT
+                                              recipient
+                                      FROM
+                                              tx_recipients i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) recipients,
+                              ARRAY(
+                                      SELECT
+                                              object_id
+                                      FROM
+                                              tx_input_objects i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) inputs,
+                              ARRAY(
+                                      SELECT
+                                              object_id
+                                      FROM
+                                              tx_changed_objects i
+                                      WHERE
+                                              i.tx_sequence_number =
+                                              t.tx_sequence_number
+                              ) changed
+                      FROM
+                              transactions t
+                      WHERE
+                              tx_sequence_number BETWEEN ? AND ?"
+                     (transactions:partition-name part))
+
+                    :tx-digests
+                    (format
+                     "INSERT INTO %s
+                       SELECT
+                               transaction_digest AS tx_digest,
+                               tx_sequence_number
+                       FROM
+                               transactions
+                       WHERE
+                               tx_sequence_number BETWEEN ? AND ?"
+                     +tx-digests+)
+                    )
+                  lo (dec hi)]
+                 (jdbc/execute! db)
+                 first :next.jdbc/update-count
+                 (hash-map :updated)))
+
+          :finalize
+          (fn [{:as task :keys [status fill updated]} signals]
+            (when (= :success status)
+              (swap! signals update fill (fnil + 0) updated)
+              nil))))
+
+(defn checkpoints:bulk-load!
+  "Load data into `+cp-tx+` corresponding to checkpoints between
+  `cp-lo` (inclusive) and `cp-hi` (exclusive). Work is split up into
+  batches of at most `batch`."
+  [db cp-lo cp-hi batch logger & {:keys [retry]}]
+  (->Pool :name   "cp:bulk-load"
+          :logger  logger
+          :workers 20
+
+          :pending
+          (or retry
+              (for [lo (range cp-lo cp-hi batch)
+                    :let [hi (min (+ lo batch) cp-hi)]]
+                {:lo lo :hi hi}))
+
+          :impl
+          (worker {:keys [lo hi]}
+            (->> [(format
+                   "INSERT INTO %s
+                    SELECT
+                            checkpoint_sequence_number,
+                            MIN(tx_sequence_number) AS min_tx_sequence_number,
+                            MAX(tx_sequence_number) AS max_tx_sequence_number
+                    FROM
+                            transactions
+                    WHERE
+                            checkpoint_sequence_number BETWEEN ? AND ?
+                    GROUP BY
+                            checkpoint_sequence_number"
+                   +cp-tx+)
+                  lo (dec hi)]
+                 (jdbc/execute! db)
+                 first :next.jdbc/update-count
+                 (hash-map :updated)))
+
+          :finalize
+          (fn [{:as task :keys [status updated]} signals]
+            (when (= :success status)
+              (swap! signals update :cp-tx (fnil + 0) updated)
+              nil))))
+
+(defn transactions:index-and-attach-partitions!
+  "Attach `part`ition`s` to the `transactions` table.
+
+  `parts` describes the partitions to attach. It is a map containing
+  the `part`ition number, its inclusive transaction lower bound, and
+  its exclusive transaction upper bound."
+  [db parts logger & {:keys [retry]}]
+  (->Pool :name   "index-and-attach"
+          :logger  logger
+          :workers 50
+
+          :pending
+          (or retry
+              (for [part parts]
+                (assoc part :job :autovacuum)))
+
+          :impl
+          (worker {:keys [part lo hi job]}
+            (case job
+              :autovacuum   (db/reset-autovacuum! db (transactions:partition-name part))
+              :analyze      (db/vacuum-and-analyze! db (transactions:partition-name part))
+              :constrain    (transactions:constrain! db part lo hi)
+              :index-filter (transactions:index-filters! db part)
+              :attach       (transactions:attach! db part lo hi)
+              :drop-check   (transactions:drop-range-check! db part))
+            nil)
+
+          :finalize
+          (fn [{:as task :keys [part lo hi status job]} signals]
+            (let [phases [:autovacuum :analyze :constrain :index-filter :attach :drop-check]
+                  edges  (into {} (map vector phases (rest phases)))]
+                (when (= :success status)
+                  (swap! signals update job (fnil inc 0))
+                  (when-let [next (edges job)]
+                    [(assoc task :job next)]))))))
+
+(defn transactions:constrain-tx!
+  "Add indices and constraints to side tables."
+  [db logger & {:keys [retry]}]
+  (->Pool :name   "index-and-constrain"
+          :logger  logger
+          :workers 10
+
+          :pending
+          (or retry
+              [{:fn tx-digests:constrain! :label :tx-digests/constrain}
+               {:fn cp-tx:constrain!      :label :cp-tx/constrain}])
+
+          :impl
+          (worker {work :fn} (work db) nil)
+
+          :finalize
+          (fn [{:keys [status label]} signals]
+            (when (= :success status)
+              (swap! signals update :done
+                     (fnil conj []) label)
+              nil))))
+
+(defn transactions:vacuum-index!
+  "Re-enable auto-vacuum on the index tables, and perform a vacuum/analyze."
+  [db logger & {:keys [retry]}]
+  (->Pool :name   "vacuum-index"
+          :logger  logger
+          :workers 10
+
+          :pending
+          (or retry
+              (map #(hash-map :job :autovacuum :index %)
+                   [+tx-digests+ +cp-tx+]))
+
+          :impl
+          (worker {:keys [job index]}
+            (case job
+              :autovacuum (db/reset-autovacuum! db index)
+              :analyze    (db/vacuum-and-analyze! db index))
+            nil)
+
+          :finalize
+          (fn [{:as task :keys [status job]} signals]
+            (when (= :success status)
+              (swap! signals update job (fnil inc 0))
+              (when (= :autovacuum job)
+                [(assoc task :job :analyze)])))))

--- a/migration_scripts/bulk_load/src/pool_v2.clj
+++ b/migration_scripts/bulk_load/src/pool_v2.clj
@@ -1,0 +1,202 @@
+(ns pool-v2
+  (:require [logger :refer [->Logger] :as l]
+            [clojure.core.async :as async
+             :refer [<!! >!! alt!! alts!! chan mult tap thread]]))
+
+(defn- queue
+  ([] clojure.lang.PersistentQueue/EMPTY)
+  ([coll] (reduce conj clojure.lang.PersistentQueue/EMPTY coll)))
+
+(defn- tapped [in]
+  (let [out (chan)]
+    (tap in out) out))
+
+(defn- ->Worker
+  "Create a new worker thread.
+
+  Workers processes batches of work sent on the `work` channel. Work
+  is processed by passing it to the `impl` function along with a
+  callback that abstracts over responding to the supervisor along with
+  `reply` channel.
+
+  The worker will stop when it receives a message on the `kill`
+  multi-channel or that channel closes."
+  [name logger impl work kill reply]
+  (let [kill (tapped kill)]
+    (thread
+      (l/log! logger "[Worker %s] Starting..." name)
+      (loop []
+        (alt!!
+          kill (l/log! logger "[Worker %s] ...shutting down." name)
+          work ([batch]
+                (try (impl batch #(>!! reply %))
+                     (catch Throwable t
+                       (l/log! logger
+                               "[Worker %s] Uncaught error on %s: %s"
+                               name batch t)))
+                (recur))))
+      ::worker-done)))
+
+(defn- ->Supervisor
+  "Create a new supervisor thread.
+
+  The supervisor is responsible for managing a queue of work that it
+  makes available over the `work` channel. It expects workers to reply
+  back on th `reply` channel when they have finished processing a
+  batch.
+
+  The supervisor's work-queue starts off populated by `pending`. Once
+  it receives a `reply` it calls `finalize` on it to potentially
+  derive more work for the queue from the results in the `reply`.
+  `finalize` can return a (possibly empty) sequence to append to the
+  queue, or `false` to indicate an unrecoverable issue (implying the
+  whole pool should wind down).
+
+  The supervisor will stop when it receives a message on the `kill*`
+  multi-channel or that channel closes. It will also close the
+  `-kill` (input) channel when it wants to stop the rest of the pool.
+
+  `signals` is an atom containing a dictionary of signals for the pool
+  to communicate with the outside world. The Supervisor itself will
+  track the number of in-flight requests and any failed jobs (replies
+  from workers with a `:status` of `:error`), and passes the signal
+  map to the `finalize` callback (as the second parameter)."
+  [name logger finalize work -kill kill* reply signals]
+  (let [kill* (tapped kill*)
+        log!(fn [f & args]
+              (apply l/log! logger (str "[Supervisor %s] " f) name args))
+        finalize (or finalize (fn [_ _] nil))]
+    (thread
+      (try
+        (log! "Starting...")
+        (loop [shutting-down false]
+          (when (and (-> @signals ::pending empty?)
+                     (-> @signals ::in-flight zero?))
+            (log! "No more work.")
+            (async/close! -kill))
+
+          (let [next (-> @signals ::pending peek)
+                [v port] (alts!! (cond-> [reply]
+                                   (not shutting-down) (conj kill*)
+                                   next (conj [work next])))]
+            (cond
+              (= port kill*)
+              (do (log! "...shutting down.")
+                  (swap! signals
+                         #(-> % (dissoc ::pending)
+                              (assoc ::cancelled (::pending %))))
+                  (recur true))
+
+              (= port work)
+              (do (log! "-> %s" next)
+                  (swap! signals
+                         #(-> % (update ::in-flight inc)
+                              (update ::pending pop)))
+                  (recur shutting-down))
+
+              (= port reply)
+              (do (log! "<- %s" v)
+                  (swap! signals
+                         #(cond-> %
+                            :always (update ::in-flight dec)
+                            :always (update ::landed inc)
+
+                            (= (:status v) :error)
+                            (update ::failed conj v)))
+                  (let [add (finalize v signals)]
+                    (if (false? add)
+                      (do (log! "Unrecoverable error!")
+                          (async/close! -kill))
+                      (do (when (not (empty? add)) (log! "++ %s" add))
+                          (swap! signals update ::pending into add)
+                          (recur shutting-down))))))))
+        ::supervisor-done
+        (catch Throwable t
+          (log! "Uncaught error: %s" t))))))
+
+(defn ->Pool
+  "Create a new pool of `workers` many workers and a supervisor to manage them.
+
+  `pending` is a collection of work items that the supervisor will
+  distribute among workers, `impl` is a function for accepting a batch
+  and completing the work, and `finalize` takes the response from
+  `impl` and updating the state of the queue with it.
+
+  `impl` accepts two parameters, the description of the work, and a
+  callback to reply on.
+
+  `finalize` accepts one parameter, the response from `impl`, and
+  returns either a collection of follow-up work, or `false` if there
+  was an unrecoverable error.
+
+  Returns an atom containing a dictionary of signals that the pool
+  uses to communicate with the outside world. The signals indicate the
+  number of in flight tasks, any failed tasks, and any other signals
+  that the `finalize` callback might add."
+  [& {:keys [name logger pending impl finalize workers]}]
+  (let* [-kill (chan) kill* (mult -kill)
+         work  (chan) reply (chan)
+
+         signals
+         (atom {::in-flight 0
+                ::landed 0
+                ::pending (queue pending)
+                ::failed []
+                ::kill -kill})
+
+         supervisor
+         (->Supervisor name logger finalize
+                       work -kill kill* reply
+                       signals)
+
+         threads
+         (->> (range workers)
+              (map #(->Worker % logger impl work kill* reply))
+              (into [supervisor]))]
+    (swap! signals assoc ::join (async/merge threads))
+    signals))
+
+(defmacro worker
+  "Create a worker function for a pool.
+
+  The worker is passed a description of the unit of work (expected to
+  be a map) which is bound to `param`, and then its `body` is
+  evaluated. The return value of `body` is merged with the description
+  of the work and sent back to the supervisor, along with a `:status`
+  of `:success`.
+
+  The returned worker detects errors (including timeouts), returning
+  the description of work with a `:status` of `:error`. Errors are
+  additionally annotated with the `:error` itself."
+  [param & body]
+  `(fn [param# reply#]
+     (try (->> (let [~param param#] ~@body)
+               (merge param# {:status :success})
+               (reply#))
+          (catch Throwable t#
+            (reply# (assoc param# :status :error :error t#))))))
+
+(defn kill!
+  "Kill a worker pool, using the `::kill` channel in its signal map."
+  [{::keys [kill]}] (async/close! kill))
+
+(defn fail-count
+  "Count the number of failed tasks in a pool's signal map."
+  [{::keys [failed]}] (count failed))
+
+(defn progress
+  "Estimate the progress of a pool based on the stats in its signal map.
+
+  Note that this is a heuristic and is only accurate if one unit of
+  work does not spawn further units of work (which may in general be
+  the case)."
+  [{::keys [pending in-flight landed]}]
+  (let [pending (count pending)
+        total (+ pending in-flight landed)]
+    {:pending pending :in-flight in-flight :landed landed :total total
+     :percent  (/ (double landed) total 1/100)}))
+
+(defn retry
+  "Gather tasks that should be retried from a signal map."
+  [{::keys [failed cancelled]}]
+  (concat failed cancelled))


### PR DESCRIPTION
## Description

Bulk loading for a new proposed transaction schema that relies on a single GIN (document index) to implement all filters. This PR also introduces a second version of the worker pool implementation that:

- Removes the support for detecting timeouts separately from errors and generally simplifies error handling: All errors are collected to be handled in another round of processing, with no retries/splitting logic.

- Couples the logic for `signals` into the `->Pool` constructor, so that the pool itself can provide signals.
  - Moves the `in-flight` count, `pending` queue, and the `join` and `kill` channels into the signals map, and provides helpers to quickly kill the pool, check on progress, or pull out tasks to resume.
  - Adds a parameter to the `finalize` function to pass in the `signals` map for any pool-specific updates, and adds logic to automatically track errors.
  - Wraps the supervisor body in a `try ... catch` so that it doesn't fail silently.

- Keeps the supervisor thread working while there are tasks in-flight, so that it can keep updating the signals map.

## Test plan

Ran the bulk loader to create `amnn_0_gin_1_transactions`, `amnn_0_gin_1_tx_digests`, `amnn_0_gin_1_cp_tx`.

## Stack

- #7 
- #9 
- #10 
- #11