### PR TITLE
[Bulk Load] 1-GIN Benchmark

### DIFF
--- a/migration_scripts/bulk_load/src/gin_1_tx_benchmark.clj
+++ b/migration_scripts/bulk_load/src/gin_1_tx_benchmark.clj
@@ -1,0 +1,123 @@
+(ns gin-1-tx-benchmark
+  (:require [combinations :refer [&& || |?]]
+            [db]
+            [hex :refer [hex->bytes]]
+            [gin-1-tx :refer [+transactions+ +tx-digests+ +cp-tx+]]
+            [alphabase.base58 :as b58]
+            [honey.sql :as sql]
+            [honey.sql.pg-ops :refer [<at]]))
+
+;; # 1-GIN Transactions Benchmark
+;;
+;; Testing out similar queries as in `tx-benchmark` and `norm-tx-benchmark` but
+;; on the 1-GIN schema.
+;;
+;; The main differences are:
+;;
+;; - Cursors refer to just the transaction sequence number, as in `norm-tx`.
+;;
+;; - All filters are applied to the `transactions` table.
+
+(defn gin-1-tx-filter
+  [& {:keys [pkg mod fun    ;; function
+             kind           ;; transaction kind
+             cp-< cp-= cp-> ;; checkpoint
+             sign recv addr ;; addresses
+             input changed  ;; objects
+             ids            ;; transaction ids
+             after before   ;; pagination
+
+             ;; Configuration
+             inline]}]
+  (let [f->  #(keyword (str %1 "." (name %2)))
+        <text (fn [val col] [<at [:array [[:cast val :text]]] col])
+        <byte (fn [val col] [<at [:array [(hex->bytes val)]] col])
+
+        joins
+        (when ids {:join [(keyword +tx-digests+) [:using :tx-sequence-number]]})
+
+        filters
+        (cond-> [:and]
+          (and pkg mod fun)
+          (conj (<text (str (hex/normalize pkg) "::" mod "::" fun) :functions))
+
+          (and pkg mod (not fun))
+          (conj (<text (str (hex/normalize pkg) "::" mod)) :modules)
+
+          (and pkg (not mod) (not fun))
+          (conj [<at [:array [(hex->bytes pkg)]] :packages])
+
+          sign (conj (<byte sign :senders))
+          recv (conj (<byte recv :recipients))
+          addr (conj [:or (<byte addr :senders) (<byte addr :recipients)])
+
+          input   (conj (<byte input :inputs))
+          changed (conj (<byte changed :changed))
+
+          ids
+          (conj [:in (f-> +tx-digests+ :tx-digest) (map b58/decode ids)])
+
+          kind (conj [:= :transaction-kind ({:programmable 0 :system 1} kind)])
+
+          cp-< (conj [:< :tx-sequence-number
+                      {:select [:min-tx-sequence-number]
+                       :from   [(keyword +cp-tx+)]
+                       :where  [:= :checkpoint-sequence-number cp-<]}])
+
+          cp-=
+          (conj [:between :tx-sequence-number
+                 {:select [:min-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp-=]}
+                 {:select [:max-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp-=]}])
+
+          cp->
+          (conj [:> :tx-sequence-number
+                 {:select [:max-tx-sequence-number]
+                  :from   [(keyword +cp-tx+)]
+                  :where  [:= :checkpoint-sequence-number cp->]}])
+
+          after  (conj [:>= :tx-sequence-number after])
+          before (conj [:<= :tx-sequence-number before]))]
+    (-> {:select [:*]
+         :from (keyword +transactions+)
+         :where filters
+         :limit 52
+         :order-by [[:tx-sequence-number :asc]]}
+        (merge joins)
+        (sql/format :inline inline))))
+
+(def inputs
+  "Lazy sequence containing various inputs to `norm-tx-filter`."
+  (&& {:kind (|? :system :programmable)}
+
+      (|? (&& {:pkg "0x2"} (|? (&& {:mod "transfer"}
+                                   {:fun (|? "public_transfer"
+                                             "public_share_object")})
+                               {:mod "package"
+                                :fun "make_immutable"}))
+          (&& {:pkg "0x225a5eb5c580cb6b6c44ffd60c4d79021e79c5a6cea7eb3e60962ee5f9bc6cb2"}
+              (|? {:mod "game_8192"
+                   :fun (|? "make_move") })))
+
+      (|| {:cp-< 10428013}
+          {:cp-= 10428013}
+          {:cp-> 10427513
+           :cp-< 10428013})
+
+      (|? {:input   "0x6"}
+          {:changed "0x6"})
+
+      (|?
+       ;; Arbitrary transactions at a variety of checkpoints
+       {:ids ["B5FEom9XbGShf9LkqgC7UzhpEvVFVk6AakhXaFyfRWRf"
+              "8GcwVK8cNqyM4CeY77Au2UfTsM6fZftSGjmfNxM8AN9"]}
+
+       ;; Transactions that modify the clock
+       {:ids ["FLqdHsKounJHXGsoT983JoZ4fuTF2UvSrVJJLDXRHqGe"
+              "85uiG9US4T4ARCiWbFSeGCawryKejZ328rxwZfysutBk"]})
+
+      (|? {:after  746619070})
+      (|? {:before 746625335})))

--- a/migration_scripts/bulk_load/src/hex.clj
+++ b/migration_scripts/bulk_load/src/hex.clj
@@ -18,3 +18,18 @@
       (partition 2 %)
       (map #(-> % s/join (Integer/parseInt 16)) %)
       (byte-array %)))
+
+(defn bytes->hex
+  "Convert a byte array into a hex string."
+  [hex]
+  (assert (= 32 (count hex))
+          "Byte arrays must be 32 bytes long")
+  (->> (map #(format "%02x" %) hex)
+       (s/join "")
+       (str "0x")))
+
+(defn normalize
+  "Normalize an address as a hex string into a standard form.
+
+  Starting with 0x, and padded out to all trailing zeroes."
+  [hex] (-> hex hex->bytes bytes->hex))


### PR DESCRIPTION
## Description

Simulate paginated transaction queries over the new proposed 1-GIN schema, and run queries over them.

## Test plan

Ran the benchmarks. For now the results seem to be comparable or slightly better than what the existing schema supports. Below are the success rates for queries involving each kind of filter, using the 1-GIN schema:

```clojure
([#{:mod} 0.6086956521739131]
 [#{:fun} 0.64]
 [#{:pkg} 0.6419753086419753]
 [#{:changed} 0.7058823529411765]
 [#{:kind} 0.7717391304347826]
 [#{:cp-<} 0.7857142857142857]
 [#{:input} 0.8]
 [#{:before} 0.8170731707317073]
 [#{:ids} 1.0]
 [#{:cp->} 1.0]
 [#{:after} 1.0]
 [#{:cp-=} 1.0])
```

And the same for the existing schema:

```clojure
([#{:mod} 0.6086956521739131]
 [#{:pkg} 0.6190476190476191]
 [#{:fun} 0.64]
 [#{:changed} 0.6486486486486487]
 [#{:kind} 0.7553191489361702]
 [#{:cp-<} 0.7692307692307693]
 [#{:input} 0.8]
 [#{:before} 0.8023952095808383]
 [#{:ids} 1.0]
 [#{:cp->} 1.0]
 [#{:after} 1.0]
 [#{:cp-=} 1.0])
```

It's possible that the dominating factor here is that queries that need to scan the whole history are not feasible rather than the issue being the number of filters that are being combined.

## Stack

- #7 
- #9 
- #10 
- #11 
- #12 
- #13 