### PR TITLE
[Bulk Load] Fixes from recent investigations

### DIFF
--- a/migration_scripts/bulk_load/src/bench.clj
+++ b/migration_scripts/bulk_load/src/bench.clj
@@ -36,14 +36,15 @@
   Returns a map from sets of keys in benchmark results to their
   success rate (proportion of queries including these keys that did
   not timeout)."
-  [results]
+  [results & {:keys [include-empty?]}]
   (let [success (atom {})
         timeout (atom {})
         or-zero  #(fn [x] (% (or x 0)))
         success! #(swap! success update % (or-zero inc))
         timeout! #(swap! timeout update % (or-zero dec))]
     (doseq [result results
-            :when (or (= :timeout (:status result))
+            :when (or include-empty?
+                      (= :timeout (:status result))
                       (pos? (:actual-rows result)))
             keys (as-> result % (keys %) (into #{} %)
                    (disj % :status :planning-time :execution-time :actual-rows)

--- a/migration_scripts/bulk_load/src/gin_1_tx_benchmark.clj
+++ b/migration_scripts/bulk_load/src/gin_1_tx_benchmark.clj
@@ -22,7 +22,7 @@
   [& {:keys [pkg mod fun    ;; function
              kind           ;; transaction kind
              cp-< cp-= cp-> ;; checkpoint
-             sign recv addr ;; addresses
+             sign recv      ;; addresses
              input changed  ;; objects
              ids            ;; transaction ids
              after before   ;; pagination
@@ -49,7 +49,6 @@
 
           sign (conj (<byte sign :senders))
           recv (conj (<byte recv :recipients))
-          addr (conj [:or (<byte addr :senders) (<byte addr :recipients)])
 
           input   (conj (<byte input :inputs))
           changed (conj (<byte changed :changed))
@@ -57,7 +56,7 @@
           ids
           (conj [:in (f-> +tx-digests+ :tx-digest) (map b58/decode ids)])
 
-          kind (conj [:= :transaction-kind ({:programmable 0 :system 1} kind)])
+          kind (conj [:= :transaction-kind ({:system 0 :programmable 1} kind)])
 
           cp-< (conj [:< :tx-sequence-number
                       {:select [:min-tx-sequence-number]

--- a/migration_scripts/bulk_load/src/norm_tx_benchmark.clj
+++ b/migration_scripts/bulk_load/src/norm_tx_benchmark.clj
@@ -73,7 +73,7 @@
   [& {:keys [pkg mod fun    ;; function
              kind           ;; transaction kind
              cp-< cp-= cp-> ;; checkpoint
-             sign recv addr ;; addresses
+             sign recv      ;; addresses
              input changed  ;; objects
              ids            ;; transaction ids
              after before   ;; pagination
@@ -125,16 +125,6 @@
 
           sign (conj [:= (f-> +tx-senders+ :sender) (hex->bytes sign)])
           recv (conj [:= (f-> +tx-recipients+ :recipient) (hex->bytes recv)])
-
-          addr
-          (conj [:in :tx-sequence-number
-                 {:union-all
-                  [{:select [:tx-sequence-number]
-                    :from   [(keyword +tx-senders+)]
-                    :where  [:= :sender (hex->bytes addr)]}
-                   {:select [:tx-sequence-number]
-                    :from   [(keyword +tx-recipients+)]
-                    :where  [:= :recipient (hex->bytes addr)]}] }])
 
           input
           (conj [:= (f-> +tx-input-objects+ :object-id) (hex->bytes input)])

--- a/migration_scripts/bulk_load/src/tx_benchmark.clj
+++ b/migration_scripts/bulk_load/src/tx_benchmark.clj
@@ -14,7 +14,7 @@
   [& {:keys [pkg mod fun    ;; function
              kind           ;; transaction kind
              cp-< cp-= cp-> ;; checkpoint
-             sign recv addr ;; addresses
+             sign recv      ;; addresses
              input changed  ;; objects
              ids            ;; transaction ids
              after before   ;; pagination
@@ -36,16 +36,13 @@
                           mod (conj [:= :module mod])
                           fun (conj [:= :func fun]))))
 
-           kind (conj [:= :transaction-kind ({:programmable 0 :system 1} kind)])
+           kind (conj [:= :transaction-kind ({:system 0 :programmable 1} kind)])
            cp-< (conj [:> cp-< :checkpoint-sequence-number])
            cp-= (conj [:= cp-= :checkpoint-sequence-number])
            cp-> (conj [:< cp-> :checkpoint-sequence-number])
 
            sign (conj (tx-in +tx-senders+    [:= :sender    (hex->bytes sign)]))
            recv (conj (tx-in +tx-recipients+ [:= :recipient (hex->bytes recv)]))
-           addr
-           (conj [:or (tx-in +tx-senders+    [:= :sender    (hex->bytes addr)])
-                      (tx-in +tx-recipients+ [:= :recipient (hex->bytes addr)])])
 
            input
            (conj (tx-in +tx-input-objects+   [:= :object-id (hex->bytes input)]))

--- a/migration_scripts/bulk_load/src/tx_filters.clj
+++ b/migration_scripts/bulk_load/src/tx_filters.clj
@@ -272,7 +272,5 @@
       {:changed tx-changed-objects}
       (|? {:sign tx-senders}
           {:recv tx-recipients}
-          {:addr tx-senders}
-          {:addr tx-recipients}
           {:ids small-tx-ids}
           checkpoints)))


### PR DESCRIPTION
## Description

A number of small fixes from recent investigations:

- Fix the mapping from transaction kind to number in the original and GIN schemas.
- Remove the `addr` filter as we're de-scoping it for now.
- Add an option to include successful but empty results when calculating success rate.
- Force use of custom plans.
- Increase working memory size to 64MB.
- Fix the representation of byte array literals when using the "inline" SQL format (as opposed to the prepared format).
- Add a helper to perform an operation within a transaction that gets rolled back, which is useful in case you want to, e.g. temporarily disable an index.

## Test plan

Used in benchmarking to date.