### PR TITLE
[Bulk Load] Simulated Benchmark

### DIFF
--- a/migration_scripts/bulk_load/src/bench.clj
+++ b/migration_scripts/bulk_load/src/bench.clj
@@ -29,29 +29,73 @@
             (when (or (= :success status) (= :timeout status))
               (swap! signals update :results conj task) nil))))
 
+(defn simulate
+  "Reinterpret `results` simulating various properties.
+
+  - Setting `timeouts` simulates a lower timeout than the benchmark
+    was actually run on (in seconds).
+
+  - Setting `no-cache?` simulates all block fetches as cache misses,
+    and updates execution time accordingly.
+
+  The result is another stream of results with its `:status` and
+  `:db/exec` fields updated according to the simulation."
+  [results & {:keys [no-cache? timeout]}]
+  (let [io-time (->> results (map :db/read) (reduce #(+ %1 (or %2 0)) 0))
+        misses  (->> results (map :db/miss) (reduce #(+ %1 (or %2 0)) 0))
+        avg-io  (/ (double io-time) misses)]
+    (cond->> results
+      no-cache?
+      (map (fn [{:as r :db/keys [exec read miss hits]}]
+             (cond-> r
+               (= :success (:status r))
+               (assoc :db/exec (-> (+ miss hits) (* avg-io)
+                                   (+ exec) (- read))))))
+      timeout
+      (map (fn [{:as r :db/keys [exec plan]}]
+             (cond-> r
+               (or (= :timeout (:status r))
+                   (> (+ exec plan) (* timeout 1000)))
+               (assoc :status :timeout)))))))
+
 (defn success-rates
   "Given a sequence of benchmark results, returns the rate at which
   queries timeout.
 
   Returns a map from sets of keys in benchmark results to their
   success rate (proportion of queries including these keys that did
-  not timeout)."
-  [results & {:keys [include-empty?]}]
-  (let [success (atom {})
+  not timeout).
+
+  `include-empty?` decides whether to include queries that succeeded
+  but returned no results.
+
+  `no-cache?` decides how the time for a benchmark run is calculated.
+  If set to `true`, time is estimated based on the number of blocks
+  read (from cache or otherwise) times the average IO time per block
+  -- as if all the blocks were read from disk, and not cache.
+
+  `timeout` is the time to consider as a timeout, in seconds. If it is
+  omitted, only queries that actually timed out when run are
+  considered timed out."
+  [results & {:keys [include-empty? no-cache? timeout]}]
+  (let [results (simulate results :no-cache? no-cache? :timeout timeout)
+
+        success (atom {})
         timeout (atom {})
-        or-zero  #(fn [x] (% (or x 0)))
-        success! #(swap! success update % (or-zero inc))
-        timeout! #(swap! timeout update % (or-zero dec))]
+        success! #(swap! success update % (fnil inc 0))
+        timeout! #(swap! timeout update % (fnil dec 0))]
     (doseq [result results
             :when (or include-empty?
                       (= :timeout (:status result))
-                      (pos? (:actual-rows result)))
+                      (pos? (:db/rows result)))
             keys (as-> result % (keys %) (into #{} %)
-                   (disj % :status :planning-time :execution-time :actual-rows)
+                       (disj % :status
+                             :db/exec :db/plan :db/read
+                             :db/rows :db/miss :db/hits)
                    (*? (lazy-seq %)))]
       (case (:status result)
-        :success (success! keys)
-        :timeout (timeout! keys)))
+        :timeout (timeout! keys)
+        :success (success! keys)))
     (-> (merge-with
           (fn [s t] (/ (double s) (- s t)))
           @success @timeout)


### PR DESCRIPTION
## Description

Make the following tweaks to the benchmarking system to simulate properties that are difficult or impossible to set-up:

- Simulate every block fetch being a cache miss by:
  - Calculating an average I/O read time per block based on the actual read times across all benchmark runs (note that this may still be susceptible to OS cache hits).
  - Replacing the read time for a given benchmark by an estimated read time calculated as the number of blocks seen (cache hits and misses) times the average I/O read time per block.

- Simulate a lower timeout than tests were actually run with so that we can see the effects of multiple timeouts in one shot.

## Test plan

Run against the current GIN schema on results from a run where the actual timeout was 10 minutes. Note that 40s without cache is slightly better than previous results where we set an actual limit of 40s (this is probably because more tests were able to complete and prime the cache), and are slightly worse when we simulate all cache misses:

Unaltered results:

```clojure
["Timed out"
 958
 "Unbounded"
 ([#{:cp->} 0.9753795126929455]
  [#{:cp-<} 0.9753795126929455]
  [#{:kind} 0.9798010149572649]
  [#{:pkg} 0.9809510030864198]
  [#{:input} 0.9820750237416904]
  [#{:sign} 0.9845085470085471]
  [#{:mod} 0.9855324074074074]
  [#{:changed} 0.9860443376068376]
  [#{:recv} 0.9866452991452992]
  [#{:fun} 0.9872202932098766]
  [#{:ids} 1.0]
  [#{:cp-=} 1.0])]
```

Simulate 40s:

```clojure
["Timed out"
 2132
 "Unbounded"
 ([#{:cp->} 0.940744992983799]
  [#{:cp-<} 0.940744992983799]
  [#{:kind} 0.9551282051282052]
  [#{:pkg} 0.9596354166666666]
  [#{:input} 0.9611823361823362]
  [#{:mod} 0.9693287037037037]
  [#{:changed} 0.9722889957264957]
  [#{:fun} 0.9731385030864198]
  [#{:sign} 0.9756944444444444]
  [#{:recv} 0.9807692307692307]
  [#{:cp-=} 0.9985042735042735]
  [#{:ids} 1.0])]
```

... with no cache:

```clojure
["Timed out"
 2617
 "Unbounded"
 ([#{:sign} 0.9332264957264957]
  [#{:cp->} 0.9372687842837096]
  [#{:cp-<} 0.9372687842837096]
  [#{:recv} 0.9407051282051282]
  [#{:kind} 0.944778311965812]
  [#{:pkg} 0.9471932870370371]
  [#{:input} 0.9491631054131054]
  [#{:changed} 0.9575320512820513]
  [#{:mod} 0.9594039351851852]
  [#{:fun} 0.9646990740740741]
  [#{:ids} 0.9764957264957265]
  [#{:cp-=} 0.9997863247863248])]
```

Simulate 60s:

```clojure
["Timed out"
 1839
 "Unbounded"
 ([#{:cp->} 0.9494833524684271]
  [#{:cp-<} 0.9494833524684271]
  [#{:kind} 0.960670405982906]
  [#{:pkg} 0.9658564814814815]
  [#{:input} 0.9665242165242165]
  [#{:mod} 0.973900462962963]
  [#{:changed} 0.9756944444444444]
  [#{:fun} 0.9772858796296297]
  [#{:sign} 0.9788995726495726]
  [#{:recv} 0.9823717948717948]
  [#{:cp-=} 0.9987179487179487]
  [#{:ids} 1.0])]
```

... with no cache:

```clojure
["Timed out"
 1843
 "Unbounded"
 ([#{:cp->} 0.9514925373134329]
  [#{:cp-<} 0.9514925373134329]
  [#{:kind} 0.9626736111111112]
  [#{:pkg} 0.9644097222222222]
  [#{:input} 0.9657822886989553]
  [#{:sign} 0.967948717948718]
  [#{:mod} 0.9728587962962963]
  [#{:changed} 0.9737913995726496]
  [#{:fun} 0.9764178240740741]
  [#{:recv} 0.9778311965811965]
  [#{:ids} 0.9957264957264957]
  [#{:cp-=} 1.0])]
```