### PR TITLE
[Footprint] Estimate cost of tracking deleted/wrapped objects

### DIFF
--- a/migration_scripts/bulk_load/src/footprint.clj
+++ b/migration_scripts/bulk_load/src/footprint.clj
@@ -1256,3 +1256,20 @@
     (->> (:objects-history tables)
          (drop-last)
          (mapv cost))))
+
+(defn delete-wrap-cost
+  "Estimate the cost due to tracking deleted and wrapped objects.
+
+  This is roughly the difference in size between `objects_snapshot`
+  and `objects`, less the size of the consistent range.
+
+  The consistent range size is estimated as the size of the last full
+  `objects_history` partition, prorated to 15 minutes."
+  [tables]
+  (let [snap  (table-footprint (:objects-snapshot tables))
+        objs  (table-footprint (:objects tables))
+        parts (partitions tables)
+
+        consistency-cost
+        (stat-footprint (get-in tables [:objects-history (- parts 2)]))]
+    (- snap objs consistency-cost)))


### PR DESCRIPTION
## Description

Estimate the cost of tracking deleted/wrapped objects as the difference in cost between the objects and objects snapshot table, less the estimated cost of the consistent range.

## Test plan

```
(use 'footprint)
(def db ...)
(def stats (table-stats db))

(->> stats delete-unwrap-cost pretty-size)
(->> stats (optimize :short-id) delete-unwrap-cost pretty-size)
```


## Stack

- #21 
- #22 
- #23 
- #24 
- #25 
- #26 
- #27 
- #28
- #29
- #30
- #31
- #32 
- #33 
- #34 
- #35 