### PR TITLE
[Footprint] Rich historical object queries

### DIFF
--- a/migration_scripts/bulk_load/src/footprint.clj
+++ b/migration_scripts/bulk_load/src/footprint.clj
@@ -1256,3 +1256,20 @@
     (->> (:objects-history tables)
          (drop-last)
          (mapv cost))))
+
+(defn delete-wrap-cost
+  "Estimate the cost due to tracking deleted and wrapped objects.
+
+  This is roughly the difference in size between `objects_snapshot`
+  and `objects`, less the size of the consistent range.
+
+  The consistent range size is estimated as the size of the last full
+  `objects_history` partition, prorated to 15 minutes."
+  [tables]
+  (let [snap  (table-footprint (:objects-snapshot tables))
+        objs  (table-footprint (:objects tables))
+        parts (partitions tables)
+
+        consistency-cost
+        (stat-footprint (get-in tables [:objects-history (- parts 2)]))]
+    (- snap objs consistency-cost)))


### PR DESCRIPTION
## Description

Simulate removing columns that could be used to support rich paginated queries at any point in history -- we don't actually offer this via the API.

Simulated in two ways: By removing the columns in postgres, and by ensuring that they get removed as part of offloading to the key-value store.

## Stack

- #21 
- #22 
- #23 
- #24 
- #25 
- #26 
- #27 
- #28
- #29
- #30
- #31
- #32 
- #33 
- #34 
- #35 
- #36 
- #37 